### PR TITLE
Remove underscores from Pull Request titles

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,7 +31,7 @@ class RebuilderJob
     output = output.gsub(api_key, 'REDACTED')
     # Only use last 64k of output
     output = output[-64_000..-1] || output
-    title = "#{country_slug}: refresh data"
+    title = "#{country_slug.gsub('_', ' ')}: refresh data"
     body = "Automated data refresh for #{country_slug} - #{legislature_slug}" \
       "\n\n#### Output\n\n```\n#{output.uncolorize}\n```"
     CreatePullRequestJob.perform_async(branch, title, body)


### PR DESCRIPTION
Ideally we would use the correct country name from 'countries.json',
however this isn't currently possible as the country_slug in the url is
actually the directory name in everypolitician-data. So we can't easily
map it to a nice country name.

For example, the url for rebuilding the United States Senate is
'/United_States_of_America/Senate', but the slug for the United States
is 'United-States-of-America'.

Ideally we should have the actual country slug in the url for the
rebuilder then map that to the correct legislature directory using
countries.json. This would also have the side benefit of not breaking if
everypolitician-data decided to change its directory structure.
