### PR TITLE
Configure rollbar for production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ gem 'puma'
 gem 'activesupport', require: 'active_support'
 gem 'everypoliticianbot', github: 'everypolitician/everypoliticianbot'
 gem 'colorize'
+
+# Report exceptions to rollbar.com
+gem 'rollbar', '~> 2.4.0'
+gem 'oj', '~> 2.12.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,9 +43,11 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     minitest (5.8.1)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     octokit (4.1.1)
       sawyer (~> 0.6.0, >= 0.5.3)
+    oj (2.12.14)
     puma (2.14.0)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -53,6 +55,8 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    rollbar (2.4.0)
+      multi_json
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -82,7 +86,9 @@ DEPENDENCIES
   dotenv
   everypoliticianbot!
   octokit
+  oj (~> 2.12.14)
   puma
+  rollbar (~> 2.4.0)
   sidekiq
   sinatra
 

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,19 @@ Dotenv.load
 require 'active_support/core_ext'
 require 'English'
 
+configure :production do
+  require 'rollbar/middleware/sinatra'
+  require 'rollbar/sidekiq'
+
+  use Rollbar::Middleware::Sinatra
+
+  Rollbar.configure do |config|
+    config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+    config.disable_monkey_patch = true
+    config.environment = settings.environment
+  end
+end
+
 EVERYPOLITICIAN_DATA_REPO = ENV.fetch(
   'EVERYPOLITICIAN_DATA_REPO',
   'everypolitician/everypolitician-data'


### PR DESCRIPTION
We want to send exception information to Rollbar in the production
environment. This change adds the gem dependencies for rollbar and
configures them for the production environment.
