### PR TITLE
Don't rebuild countries.json in the rebuilder

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,6 @@ class RebuilderJob
       Dir.chdir(File.join('data', country_slug, legislature_slug)) do
         output = run('bundle exec rake clobber default 2>&1')
       end
-      warn run('bundle exec rake countries.json')
     end
     api_key = ERB::Util.url_encode(ENV['MORPH_API_KEY'])
     output = output.gsub(api_key, 'REDACTED')


### PR DESCRIPTION
This doesn't work as expected because there isn't a commit after the
data is rebuilt so there's nothing to update in countries.json.

This also had another subtle problem where if there was nothing to be
rebuilt for the country but there was a change to countries.json it
would make a commit just updating the countries.json file, which isn't
the job of this repo.
