### PR TITLE
Don't send Pull Requests to Dead Job Queue

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -90,7 +90,7 @@ class CreatePullRequestJob
   include Everypoliticianbot::Github
 
   # Only retry 3 times before moving to dead job queue
-  sidekiq_options retry: 3
+  sidekiq_options retry: 3, dead: false
 
   def perform(branch, title, body)
     fail Error, "Couldn't find branch: #{branch}" unless branch_exists?(branch)


### PR DESCRIPTION
If a CreatePullRequest job fails more than 3 times then it probably means that there were no changes so the branch wasn't actually pushed. If this is the case then we can safely ignore that branch rather than sending it to the Dead Job Queue.
