### PR TITLE
Only create Pull Request if Popolo has changed

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -93,6 +93,12 @@ class CreatePullRequestJob
   sidekiq_options retry: 3, dead: false
 
   def perform(branch, title, body)
+    changes = github.compare(EVERYPOLITICIAN_DATA_REPO, 'master', branch)
+    changed_files = changes[:files].map { |f| File.basename(f[:filename]) }
+    unless changed_files.include?('ep-popolo-v1.0.json')
+      warn "No change to ep-popolo-v1.0.json detected, skipping"
+      return
+    end
     fail Error, "Couldn't find branch: #{branch}" unless branch_exists?(branch)
     github.create_pull_request(
       EVERYPOLITICIAN_DATA_REPO,


### PR DESCRIPTION
If there are no changes to ep-popolo-v1.0.json then don't create the
Pull Request on everypolitician-data.

This takes the simple route of allowing the branch to be created first,
and then comparing the branch with master to see what has changed. This
means that there will be some branches that get pushed but don't get a
Pull Request created for them because they don't change the Popolo.
Perhaps this is a good thing since it means that if you want/need to
create a Pull Request for a non-Popolo change you can do so manually.

Fixes https://github.com/everypolitician/everypolitician/issues/264
