### PR TITLE
Report errors to Rollbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :test do
 end
 
 # Report exceptions to rollbar.com
-gem 'rollbar', '~> 2.4.0'
+gem 'rollbar', '~> 2.8.0'
 gem 'oj', '~> 2.12.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rollbar (2.4.0)
+    rollbar (2.8.0)
       multi_json
     safe_yaml (1.0.4)
     sawyer (0.6.0)
@@ -108,11 +108,11 @@ DEPENDENCIES
   puma
   rack-test
   rake
-  rollbar (~> 2.4.0)
+  rollbar (~> 2.8.0)
   sidekiq
   sinatra
   vcr
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app.rb
+++ b/app.rb
@@ -78,7 +78,7 @@ class RebuilderJob
   def run(command, extra_env = {})
     output = IO.popen(env.merge(extra_env), command, &:read)
     return output if $CHILD_STATUS.success?
-    warn output
+    Rollbar.warn(command, output)
     fail SystemCallFail, "#{command} #{$CHILD_STATUS}"
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -73,13 +73,11 @@ class RebuilderJob
     }
   end
 
-  class SystemCallFail < StandardError; end
-
   def run(command, extra_env = {})
     output = IO.popen(env.merge(extra_env), command, &:read)
     return output if $CHILD_STATUS.success?
     Rollbar.warn(command, output)
-    fail SystemCallFail, "#{command} #{$CHILD_STATUS}"
+    warn "#{command} #{$CHILD_STATUS}"
   end
 end
 


### PR DESCRIPTION
Rather than sending warnings to Heroku logs and then raising exceptions that aren't obvious this changes things around so that the output of the failed command gets sent to Rollbar so that it's easier to see _why_ a build failed.
