### PR TITLE
Reduce the amount of noise in the logs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -40,7 +40,7 @@ class RebuilderJob
     output = ''
     child_status = nil
     with_git_repo(EVERYPOLITICIAN_DATA_REPO, options) do
-      run('bundle install')
+      run('bundle install --quiet')
       Dir.chdir(File.dirname(legislature.popolo)) do
         if source
           output, child_status = run('bundle exec rake clean default 2>&1', 'REBUILD_SOURCE' => source)


### PR DESCRIPTION
It can be hard to see what's going on in the logs when there are lots of
lines of output from bundle install. These lines don't tell us anything
particularly useful so silence them so we don't miss any actual errors.
