### PR TITLE
Reduce the size of job arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ cache: bundler
 rvm:
   - 2.2.3
 before_install: gem install bundler -v 1.10.6
+services:
+  - redis-server

--- a/test/rebuilder_job_test.rb
+++ b/test/rebuilder_job_test.rb
@@ -35,6 +35,7 @@ Automated data refresh for Australia - Senate
 Build output
 ```
     EXPECTED
-    assert_equal expected, args[2]
+    assert_equal expected, Sidekiq.redis { |conn| conn.get("body:#{args[0]}") }
+    Sidekiq.redis { |conn| conn.del("body:#{args[0]}") }
   end
 end


### PR DESCRIPTION
Rather than passing the whole build output to the pull request job we
instead put it in Redis. This means that the arguments to the job are
kept nice and small, as they should be.

Part of https://github.com/everypolitician/rebuilder/issues/24
