### PR TITLE
Make the output from the build hang around for longer

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -67,7 +67,7 @@ class RebuilderJob
     Sidekiq.redis do |conn|
       key = "body:#{branch}"
       conn.set(key, body)
-      conn.expire(key, 1.hour)
+      conn.expire(key, 6.hours)
 
       # Wait so the branch is available through GitHub's API.
       # If the job executes immediately then the branch may not


### PR DESCRIPTION
We've only got a single worker doing the rebuilds and the pull requests,
so when it gets busy it can be more than an hour between the rebuild
happening and the pull request being created, which was leading to the
output from the build getting lost.

This temporarily puts that timeout up to 6 hours while we figure out
better ways to speed up the pipeline.
