### PR TITLE
Add separate queue for pull requests

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma --threads 5:5 --port $PORT
-worker: bundle exec sidekiq -r ./app.rb -c 1
+worker: bundle exec sidekiq -r ./app.rb -c 1 -q default -q pull_requests

--- a/app.rb
+++ b/app.rb
@@ -102,7 +102,7 @@ class CreatePullRequestJob
   include Everypoliticianbot::Github
 
   # Only retry 3 times, then discard the job
-  sidekiq_options retry: 3, dead: false
+  sidekiq_options retry: 3, dead: false, queue: 'pull_requests'
 
   def perform(branch, title, body_key)
     # The branch won't exist if there were no changes when the rebuild was run.


### PR DESCRIPTION
This will hopefully mean that creating pull requests isn't blocked
waiting for rebuilds to complete.
