### PR TITLE
Give the pull request queue priority

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma --threads 5:5 --port $PORT
-worker: bundle exec sidekiq -r ./app.rb -c 1 -q default -q pull_requests
+worker: bundle exec sidekiq -r ./app.rb -c 1 -q pull_requests -q default


### PR DESCRIPTION
We want the pull requests to get processed immediately since a job can only make it into that queue if it's already been rebuilt into a branch.

Sidekiq will process the queues in the [order that they are declared on the command line](https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues).
