### PR TITLE
Refresh countries.json after rebuilding a legislature

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,6 +61,11 @@ class RebuilderJob
         end
       end
     end
+
+    with_git_repo.commit_changes_to_branch(branch, "Refresh countries.json") do
+      run('bundle exec rake countries.json')
+    end
+
     unless child_status && child_status.success?
       Rollbar.error("Failed to build #{country.name} - #{legislature.name}\n\n" + output)
       return


### PR DESCRIPTION
Rather than having to wait for another bot to come in and update `countries.json` we do it after we've done the rebuild. This means that the pull request that comes from the rebuilder will be immediately mergeable, if that's needed.

An example of this in action is here - https://github.com/chrismytton/everypolitician-data/pull/5

This should also indirectly help with https://github.com/everypolitician/everypolitician/issues/359.
