### PR TITLE
Pass EP_COUNTRY_REFRESH option to rake countries.json

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -63,7 +63,7 @@ class RebuilderJob
     end
 
     with_git_repo.commit_changes_to_branch(branch, "Refresh countries.json") do
-      run('bundle exec rake countries.json')
+      run('bundle exec rake countries.json', 'EP_COUNTRY_REFRESH' => country_slug)
     end
 
     unless child_status && child_status.success?


### PR DESCRIPTION
This means that only a single country will be rebuilt in `countries.json`.
This should be significantly faster than rebuilding the whole thing and
has the bonus of not producing unnecessary diffs.

[Fixes this comment](https://github.com/everypolitician/rebuilder/pull/35/files/5abaaf0d2d6464cfee4d26e888153e9305cb781b#r74461236)
