### PR TITLE
Update Rollbar to 2.13.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :test do
 end
 
 # Report exceptions to rollbar.com
-gem 'rollbar', '~> 2.8.0'
+gem 'rollbar', '~> 2.13'
 gem 'oj', '~> 2.12.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     minitest (5.8.1)
     minitest-around (0.3.2)
       minitest (~> 5.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     octokit (4.1.1)
       sawyer (~> 0.6.0, >= 0.5.3)
@@ -56,7 +56,7 @@ GEM
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rollbar (2.8.0)
+    rollbar (2.13.1)
       multi_json
     safe_yaml (1.0.4)
     sawyer (0.6.0)
@@ -101,7 +101,7 @@ DEPENDENCIES
   puma
   rack-test
   rake
-  rollbar (~> 2.8.0)
+  rollbar (~> 2.13)
   sidekiq
   sinatra
   vcr

--- a/app.rb
+++ b/app.rb
@@ -7,7 +7,6 @@ require 'English'
 
 configure :production do
   require 'rollbar/middleware/sinatra'
-  require 'rollbar/sidekiq'
 
   use Rollbar::Middleware::Sinatra
 


### PR DESCRIPTION
This is the latest version of the Rollbar gem and should fix the
warnings we get from it about running an outdated version.

I've also removed a require from `app.rb` that's no longer needed in the
latest Rollbar as plugins are now automatically loaded.
