### PR TITLE
Upgrade to Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2.3
+  - 2.3.1
 before_install: gem install bundler -v 1.10.6
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.3'
+ruby '2.3.1'
 
 gem 'sinatra'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,5 +108,8 @@ DEPENDENCIES
   webmock
   with_git_repo
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.13.5


### PR DESCRIPTION
We updated the minimum Ruby version for everypolitician-data to 2.3.1 in https://github.com/everypolitician/everypolitician-data/pull/19460, so we need the rebuilder to also be running that version.