### PR TITLE
Don't send Sinatra::NotFound errors to Rollbar

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -16,6 +16,7 @@ configure :production do
     config.environment = settings.environment
     config.framework = "Sinatra: #{Sinatra::VERSION}"
     config.root = Dir.pwd
+    config.exception_level_filters.merge('Sinatra::NotFound' => 'ignore')
   end
 end
 


### PR DESCRIPTION
Previously we were sending an error notification to Rollbar whenever there was a 404. We don't need to know about this, at least not in Rollbar, so ignore this exception.

# Notes to reviewer

I'm afraid this is one of those pull requests where the only way to actually test it is to put it in production and observe it working (or not!).