### PR TITLE
Add homepage with bot image on

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -167,6 +167,10 @@ class CreatePullRequestJob
   end
 end
 
+get '/' do
+  erb :bot_image
+end
+
 post '/:country/:legislature' do |country_path, legislature_path|
   logger.warn "Legacy route used: /#{country_path}/#{legislature_path}. Please use / with params"
   countries = Everypolitician::CountriesJson.new

--- a/views/bot_image.erb
+++ b/views/bot_image.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EveryPolitician Rebuilder</title>
+    <style>
+      body {
+        max-width: 400px;
+        margin: 0 auto;
+        padding: 10px;
+        background-color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://medium.com/@everypolitician/getting-busy-with-scraper-data-957a2ddd9963">
+      <img alt="EveryPolitician Bot" src="https://avatars0.githubusercontent.com/u/12693984?v=3&amp;s=800" width="400" height="400">
+    </a>
+  </body>
+</html>


### PR DESCRIPTION
Rather than having a 404 on the homepage show an image of the bot and
link to a [relevant blog post](https://medium.com/@everypolitician/getting-busy-with-scraper-data-957a2ddd9963).

![screen shot 2016-12-15 at 18 01 25](https://cloud.githubusercontent.com/assets/22996/21233742/985e395c-c2f0-11e6-97f8-09e5e0bdb1ff.png)
