### PR TITLE
Revert "Don't send Sinatra::NotFound errors to Rollbar"

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -16,7 +16,6 @@ configure :production do
     config.environment = settings.environment
     config.framework = "Sinatra: #{Sinatra::VERSION}"
     config.root = Dir.pwd
-    config.exception_level_filters.merge('Sinatra::NotFound' => 'ignore')
   end
 end
 


### PR DESCRIPTION
This doesn't seem to work as expected. After deploying to the live site I was still seeing errors like this in the logs:

```
2016-12-15T17:03:43.970058+00:00 app[web.1]: D, [2016-12-15T17:03:43.969955 #4] DEBUG -- : [Rollbar] Reporting exception: Sinatra::NotFound
2016-12-15T17:03:43.988052+00:00 app[web.1]: I, [2016-12-15T17:03:43.987937 #4]  INFO -- : [Rollbar] Scheduling item
2016-12-15T17:03:43.988101+00:00 app[web.1]: I, [2016-12-15T17:03:43.988052 #4]  INFO -- : [Rollbar] Sending item
2016-12-15T17:03:44.170064+00:00 app[web.1]: W, [2016-12-15T17:03:44.169948 #4]  WARN -- : [Rollbar] Got unexpected status code from Rollbar api: 429
```

Reverting this for now. I've added a homepage in #50 so that should stop the majority of 404 errors that we're getting.

Reverts everypolitician/rebuilder#49