### PR TITLE
Check for existing rebuilds

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -169,15 +169,22 @@ class CreatePullRequestJob
   end
 end
 
+module Rebuilder
+  class Queue
+    def add(country, legislature, source = nil)
+      if Sidekiq::Queue.new.map(&:args).any? { |args| args == [country, legislature, source] }
+        "Existing job found for #{[country, legislature, source].inspect}, skipping."
+      else
+        RebuilderJob.perform_async(country, legislature, source)
+        "Queued rebuild for country=#{country} legislature=#{legislature} source=#{source}\n"
+      end
+    end
+  end
+end
+
 helpers do
   def rebuild(country, legislature, source = nil)
-    if Sidekiq::Queue.new.map(&:args).any? { |args| args == [country, legislature, source] }
-      error = "Existing job found for #{args.inspect}, skipping."
-      logger.warn(error)
-      return error
-    end
-    RebuilderJob.perform_async(country, legislature, source)
-    message = "Queued rebuild for country=#{country} legislature=#{legislature} source=#{source}\n"
+    message = Rebuilder::Queue.new.add(country, legislature, source)
     logger.warn(message)
     message
   end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -12,11 +12,11 @@ describe 'Rebuilder' do
     end
 
     it 'queues one job' do
-      assert_equal 1, RebuilderJob.jobs.size
+      assert_equal 1, Sidekiq::Queue.new.size
     end
 
     it 'has the correct arguments' do
-      assert_equal ['Thailand', 'National-Legislative-Assembly', nil], RebuilderJob.jobs.first['args']
+      assert_equal ['Thailand', 'National-Legislative-Assembly', nil], Sidekiq::Queue.new.first['args']
     end
 
     it 'confirms rebuild in response body' do
@@ -32,11 +32,11 @@ describe 'Rebuilder' do
     end
 
     it 'queues one job' do
-      assert_equal 1, RebuilderJob.jobs.size
+      assert_equal 1, Sidekiq::Queue.new.size
     end
 
     it 'has the correct arguments' do
-      assert_equal ['Thailand', 'National-Legislative-Assembly', nil], RebuilderJob.jobs.first['args']
+      assert_equal ['Thailand', 'National-Legislative-Assembly', nil], Sidekiq::Queue.new.first['args']
     end
 
     it 'confirms rebuild in response body' do
@@ -52,11 +52,11 @@ describe 'Rebuilder' do
     end
 
     it 'queues one job' do
-      assert_equal 1, RebuilderJob.jobs.size
+      assert_equal 1, Sidekiq::Queue.new.size
     end
 
     it 'has the correct arguments' do
-      assert_equal %w(Thailand National-Legislative-Assembly gender-balance), RebuilderJob.jobs.first['args']
+      assert_equal %w(Thailand National-Legislative-Assembly gender-balance), Sidekiq::Queue.new.first['args']
     end
 
     it 'confirms rebuild in response body' do

--- a/test/rebuilder/queue_test.rb
+++ b/test/rebuilder/queue_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe Rebuilder::Queue do
+  describe 'rebuilding the same legislature multiple times' do
+    before do
+      2.times do
+        Rebuilder::Queue.new.add('Thailand', 'National-Legislative-Assembly', 'gender-balance')
+      end
+    end
+
+    it 'only queues one job up' do
+      assert_equal 1, Sidekiq::Queue.new.size
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 ENV['RACK_ENV'] = 'test'
 require 'minitest/autorun'
-require 'sidekiq/testing'
 require 'rack/test'
-
-Sidekiq::Testing.fake!
 
 module SidekiqMinitestSupport
   def after_teardown
-    Sidekiq::Worker.clear_all
+    Sidekiq::Queue.new.clear
   end
 end
 


### PR DESCRIPTION
This checks for existing jobs before re-queueing them, which should help keep the size of the rebuild queue down.

Fixes #37 

# Note to merger

Make sure the following have been done before merging this:

- [x] Change the base of this pull request to `master` once #53 has been merged.