### PR TITLE
Reduce duplication in routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -168,6 +168,15 @@ class CreatePullRequestJob
   end
 end
 
+helpers do
+  def rebuild(country, legislature, source = nil)
+    RebuilderJob.perform_async(country, legislature, source)
+    message = "Queued rebuild for country=#{country} legislature=#{legislature} source=#{source}\n"
+    logger.warn(message)
+    message
+  end
+end
+
 get '/' do
   erb :bot_image
 end

--- a/app.rb
+++ b/app.rb
@@ -187,8 +187,7 @@ post '/:country/:legislature' do |country_path, legislature_path|
   countries.each do |country|
     country[:legislatures].each do |legislature|
       if File.dirname(legislature[:popolo]) == "data/#{country_path}/#{legislature_path}"
-        RebuilderJob.perform_async(country[:slug], legislature[:slug])
-        return "Queued rebuild for #{country[:slug]} #{legislature[:slug]}\n"
+        return rebuild(country[:slug], legislature[:slug])
       end
     end
   end

--- a/app.rb
+++ b/app.rb
@@ -198,6 +198,5 @@ post '/' do
   country = params[:country]
   legislature = params[:legislature]
   source = params[:source]
-  RebuilderJob.perform_async(country, legislature, source)
-  "Queued rebuild for country=#{country} legislature=#{legislature} source=#{source}\n"
+  rebuild(country, legislature, source)
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -16,11 +16,11 @@ describe 'Rebuilder' do
     end
 
     it 'has the correct arguments' do
-      assert_equal %w(Thailand National-Legislative-Assembly), RebuilderJob.jobs.first['args']
+      assert_equal ['Thailand', 'National-Legislative-Assembly', nil], RebuilderJob.jobs.first['args']
     end
 
     it 'confirms rebuild in response body' do
-      assert_equal "Queued rebuild for Thailand National-Legislative-Assembly\n", last_response.body
+      assert_equal "Queued rebuild for country=Thailand legislature=National-Legislative-Assembly source=\n", last_response.body
     end
   end
 


### PR DESCRIPTION
This pull request moves the duplication between the legacy route and the modern route into a shared helper method. This new helper handles queueing up the background job and returning an appropriate message.

This was previously part of https://github.com/everypolitician/rebuilder/pull/54 but it makes sense to do as a separate change.

By doing this we'll make it easier to implement #37.