### PR TITLE
Add route for url-based rebuild of a specific source

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -199,3 +199,7 @@ post '/' do
   source = params[:source]
   rebuild(country, legislature, source)
 end
+
+post '/rebuild/:country_slug/:legislature_slug/?:source_name?' do |country_slug, legislature_slug, source_name|
+  rebuild(country_slug, legislature_slug, source_name)
+end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -63,4 +63,46 @@ describe 'Rebuilder' do
       last_response.body.must_equal "Queued rebuild for country=Thailand legislature=National-Legislative-Assembly source=gender-balance\n"
     end
   end
+
+  describe 'url-based rebuilds using country and legislature slugs' do
+    describe 'without a source' do
+      before { post '/rebuild/Thailand/National-Legislative-Assembly' }
+
+      it 'is successful' do
+        last_response.status.must_equal 200
+      end
+
+      it 'queues one job' do
+        RebuilderJob.jobs.size.must_equal 1
+      end
+
+      it 'has the correct arguments' do
+        RebuilderJob.jobs.first['args'].must_equal ['Thailand', 'National-Legislative-Assembly', nil]
+      end
+
+      it 'confirms rebuild in response body' do
+        last_response.body.must_equal "Queued rebuild for country=Thailand legislature=National-Legislative-Assembly source=\n"
+      end
+    end
+
+    describe 'with a source' do
+      before { post '/rebuild/Thailand/National-Legislative-Assembly/gender-balance' }
+
+      it 'is successful' do
+        last_response.status.must_equal 200
+      end
+
+      it 'queues one job' do
+        RebuilderJob.jobs.size.must_equal 1
+      end
+
+      it 'has the correct arguments' do
+        RebuilderJob.jobs.first['args'].must_equal %w(Thailand National-Legislative-Assembly gender-balance)
+      end
+
+      it 'confirms rebuild in response body' do
+        last_response.body.must_equal "Queued rebuild for country=Thailand legislature=National-Legislative-Assembly source=gender-balance\n"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This route can be used by scrapers as the webhook url, which allows us
to have the webhook only trigger a rebuild for the source that the
scraper provides.

Fixes https://github.com/everypolitician/rebuilder/issues/41