### PR TITLE
Add source name to generated pull request's title

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -67,8 +67,9 @@ class RebuilderJob
       Rollbar.error("Failed to build #{country.name} - #{legislature.name}\n\n#{cleaned_output}")
       return
     end
-    title = "#{country.name} (#{legislature.name}): refresh data"
-    body = "Automated data refresh for #{country.name} - #{legislature.name}" \
+    source_name_with_default = source || 'all sources'
+    title = "#{country.name} (#{legislature.name}): refresh #{source_name_with_default}"
+    body = "Automated refresh of #{source_name_with_default} for #{country.name} - #{legislature.name}" \
       "\n\n#### Output\n\n```\n#{cleaned_output}\n```"
     Sidekiq.redis do |conn|
       key = "body:#{branch}"


### PR DESCRIPTION
This adds the name of the source that was rebuilt to the pull request title if a rebuild for a single source has been requested.

# Notes to reviewer

I tried adding some tests for this but didn't get very far because of the complexity of the `RebuilderJob#perform` method. I've opened #62 to track refactoring that, but we think that getting this fix in still adds value, even if it isn't tested.

Fixes https://github.com/everypolitician/rebuilder/issues/59