### PR TITLE
Extract ExternalCommand and CleanedOutput classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,24 @@ Run the app server
 You can then trigger a rebuild using `curl(1)`:
 
     curl -i -X POST -d 'country=Australia' -d 'legislature=Senate' http://localhost:5000/
+
+## Architecture
+
+### Running external commands
+
+The main task this app performs is running the EveryPolitician build process as an external command and then creating a pull request with the output from the command. As such, one of the main classes in the system is the `ExternalCommand` class. This encapsulates running an external command, checking for errors and returning the output.
+
+To use this class create an instance of `ExternalCommand` and pass `command` and `env` keyword arguments to the constructor. The `command` should be a string representing the external command to execute, and `env` is an optional hash containing environment variables that should be set, or if they are `nil`, unset.
+
+Note that a given instance will only run an external command once. Create a new instance if you need to run the command again.
+
+```ruby
+command = ExternalCommand.new(
+  command: 'echo "Hello, $name."',
+  env: { 'name' => 'Bob' }
+).run
+
+# Now you can access the output and status of the command.
+command.output # => "Hello, Bob.\n"
+command.success? # => true
+```

--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ command = ExternalCommand.new(
 command.output # => "Hello, Bob.\n"
 command.success? # => true
 ```
+
+### Cleaning the output from external commands
+
+The output of external commands is included in the resulting pull request that the Rebuilder creates. Before including it in a pull request the output needs to be cleaned to remove any API keysand strip color escape codes. Use the `CleanedOutput` class to obtain a cleaned version of an external command's output.
+
+```ruby
+cleaned_output = CleanedOutput.new(output: 'API Key: Test', morph_api_key: 'Test')
+puts cleaned_output.to_s # => "API Key: REDACTED"
+```

--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,7 @@ Bundler.require
 Dotenv.load
 
 require 'active_support/core_ext'
-require 'English'
+require_relative 'lib/external_command'
 
 configure :production do
   require 'rollbar/middleware/sinatra'

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'colorize'
+
+class CleanedOutput
+  def initialize(output:)
+    @output = output
+  end
+
+  def to_s
+    cleaned_output[-64_000..-1] || cleaned_output
+  end
+
+  private
+
+  def cleaned_output
+    output.gsub(morph_api_key, 'REDACTED').uncolorize
+  end
+
+  def morph_api_key
+    ERB::Util.url_encode(ENV['MORPH_API_KEY'])
+  end
+
+  attr_reader :output
+end

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -8,7 +8,7 @@ class CleanedOutput
   end
 
   def to_s
-    cleaned_output[-64_000..-1] || cleaned_output
+    (cleaned_output[-64_000..-1] || cleaned_output).uncolorize
   end
 
   private
@@ -16,7 +16,8 @@ class CleanedOutput
   attr_reader :output, :morph_api_key
 
   def cleaned_output
-    output.gsub(morph_api_key_encoded, 'REDACTED').uncolorize
+    return output if morph_api_key_encoded.empty?
+    output.gsub(morph_api_key_encoded, 'REDACTED')
   end
 
   def morph_api_key_encoded

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -2,8 +2,9 @@
 require 'colorize'
 
 class CleanedOutput
-  def initialize(output:)
+  def initialize(output:, morph_api_key: ENV['MORPH_API_KEY'])
     @output = output
+    @morph_api_key = morph_api_key
   end
 
   def to_s
@@ -12,13 +13,13 @@ class CleanedOutput
 
   private
 
+  attr_reader :output, :morph_api_key
+
   def cleaned_output
-    output.gsub(morph_api_key, 'REDACTED').uncolorize
+    output.gsub(morph_api_key_encoded, 'REDACTED').uncolorize
   end
 
-  def morph_api_key
-    ERB::Util.url_encode(ENV['MORPH_API_KEY'])
+  def morph_api_key_encoded
+    ERB::Util.url_encode(morph_api_key)
   end
-
-  attr_reader :output
 end

--- a/lib/external_command.rb
+++ b/lib/external_command.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'English'
+require_relative 'external_command/result'
+
+class ExternalCommand
+  def initialize(command:, env: {})
+    @command = command
+    @env = env
+  end
+
+  def run
+    Result.new(
+      output:       IO.popen(default_env.merge(env), command, &:read),
+      child_status: $CHILD_STATUS
+    )
+  end
+
+  private
+
+  attr_reader :env, :command
+
+  # Unset bundler environment variables so it uses the correct Gemfile etc.
+  def default_env
+    @default_env ||= {
+      'BUNDLE_GEMFILE'                => nil,
+      'BUNDLE_BIN_PATH'               => nil,
+      'RUBYOPT'                       => nil,
+      'RUBYLIB'                       => nil,
+      'NOKOGIRI_USE_SYSTEM_LIBRARIES' => '1',
+    }
+  end
+end

--- a/lib/external_command/result.rb
+++ b/lib/external_command/result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ExternalCommand
+  class Result
+    attr_reader :output
+
+    def initialize(output:, child_status:)
+      @output = output
+      @child_status = child_status
+    end
+
+    def success?
+      child_status.success?
+    end
+
+    private
+
+    attr_reader :child_status
+  end
+end

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'CleanedOutput' do
+  describe 'basic output' do
+    subject { CleanedOutput.new(output: 'Hello, world') }
+
+    it 'returns it untouched' do
+      subject.to_s.must_equal 'Hello, world'
+    end
+  end
+
+  describe 'output containing Morph API key' do
+    before do
+      @old_key = ENV['MORPH_API_KEY']
+      ENV['MORPH_API_KEY'] = 'test-morph-api-key'
+    end
+
+    after { ENV['MORPH_API_KEY'] = @old_key }
+
+    subject { CleanedOutput.new(output: 'Key: test-morph-api-key') }
+
+    it 'removes the key from the output' do
+      subject.to_s.must_equal 'Key: REDACTED'
+    end
+  end
+
+  describe 'with color escape codes in output' do
+    let(:output) { '[0;31;49mTest[0m' }
+    subject { CleanedOutput.new(output: output) }
+
+    it 'strips escape codes' do
+      subject.to_s.must_equal 'Test'
+    end
+  end
+
+  describe 'large output' do
+    let(:output) { 'x' * 100_000 }
+    subject { CleanedOutput.new(output: output) }
+
+    it 'only returns that last 64k' do
+      subject.to_s.size.must_equal 64_000
+    end
+  end
+end

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -23,6 +23,19 @@ describe 'CleanedOutput' do
     end
   end
 
+  describe 'no morph API key' do
+    subject do
+      CleanedOutput.new(
+        output:        'Test',
+        morph_api_key: nil
+      )
+    end
+
+    it 'removes the key from the output' do
+      subject.to_s.must_equal 'Test'
+    end
+  end
+
   describe 'with color escape codes in output' do
     let(:output) { '[0;31;49mTest[0m' }
     subject { CleanedOutput.new(output: output) }

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -11,14 +11,12 @@ describe 'CleanedOutput' do
   end
 
   describe 'output containing Morph API key' do
-    before do
-      @old_key = ENV['MORPH_API_KEY']
-      ENV['MORPH_API_KEY'] = 'test-morph-api-key'
+    subject do
+      CleanedOutput.new(
+        output:        'Key: test-morph-api-key',
+        morph_api_key: 'test-morph-api-key'
+      )
     end
-
-    after { ENV['MORPH_API_KEY'] = @old_key }
-
-    subject { CleanedOutput.new(output: 'Key: test-morph-api-key') }
 
     it 'removes the key from the output' do
       subject.to_s.must_equal 'Key: REDACTED'

--- a/test/external_command_test.rb
+++ b/test/external_command_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+describe 'ExternalCommand' do
+  describe 'running a simple command' do
+    subject { ExternalCommand.new(command: 'echo Hello, world.').run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "Hello, world.\n"
+    end
+
+    it 'is considered to be successful' do
+      subject.success?.must_equal true
+    end
+  end
+
+  describe 'running a command with environment variables set' do
+    subject { ExternalCommand.new(command: 'echo Hello, $name.', env: { 'name' => 'Bob' }).run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "Hello, Bob.\n"
+    end
+
+    it 'is considered to be successful' do
+      subject.success?.must_equal true
+    end
+  end
+
+  describe 'running an external command that fails' do
+    subject { ExternalCommand.new(command: 'echo fail; exit 1').run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "fail\n"
+    end
+
+    it 'is considered to be a failure' do
+      subject.success?.must_equal false
+    end
+  end
+end


### PR DESCRIPTION
This adds two new classes, `ExternalCommand`, which runs external commands and captures their output, and `CleanedOutput`, which cleans up the output from external commands ready for inclusion in a pull request.

Fixes #43 
Fixes #45 
Part of #62 