### PR TITLE
Extract class for cleaning output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ Run the app server
 You can then trigger a rebuild using `curl(1)`:
 
     curl -i -X POST -d 'country=Australia' -d 'legislature=Senate' http://localhost:5000/
+
+## Architecture
+
+### Cleaning the output from external commands
+
+The output of external commands is included in the resulting pull request that the Rebuilder creates. Before including it in a pull request the output needs to be cleaned to remove any API keysand strip color escape codes. Use the `CleanedOutput` class to obtain a cleaned version of an external command's output.
+
+```ruby
+cleaned_output = CleanedOutput.new(output: 'key=secret pw=password', redactions: ['secret', 'password'])
+puts cleaned_output.to_s # => "key=REDACTED pw=REDACTED"
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ You can then trigger a rebuild using `curl(1)`:
 
 ### Cleaning the output from external commands
 
-The output of external commands is included in the resulting pull request that the Rebuilder creates. Before including it in a pull request the output needs to be cleaned to remove any API keysand strip color escape codes. Use the `CleanedOutput` class to obtain a cleaned version of an external command's output.
+The output of external commands is included in the resulting pull request that the Rebuilder creates. Before including it in a pull request the output needs to be cleaned up. We currently apply the following transforms:
+
+- Apply a set of redactions to protect API keys etc
+- Strip color escape codes from the output
+- Return only the last n characters of the body (default 64,000, for using in GitHub comments)
+
+Use the `CleanedOutput` class to obtain a cleaned version of an external command's output.
 
 ```ruby
 cleaned_output = CleanedOutput.new(output: 'key=secret pw=password', redactions: ['secret', 'password'])

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -5,7 +5,7 @@ require 'erb'
 class CleanedOutput
   def initialize(output:, redactions: [], max_body_size: 64_000)
     @output = output
-    @redactions = redactions
+    @redactions = [redactions].flatten
     @max_body_size = max_body_size
   end
 

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -30,7 +30,7 @@ class CleanedOutput
   end
 
   def redact(out)
-    redactions.reduce(out) do |s, redaction|
+    redactions.reject { |r| r.nil? || r.empty? }.reduce(out) do |s, redaction|
       s.gsub(ERB::Util.url_encode(redaction), 'REDACTED')
     end
   end

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -3,9 +3,10 @@ require 'colorize'
 require 'erb'
 
 class CleanedOutput
-  def initialize(output:, redactions: [])
+  def initialize(output:, redactions: [], max_body_size: 64_000)
     @output = output
     @redactions = redactions
+    @max_body_size = max_body_size
   end
 
   def to_s
@@ -14,14 +15,14 @@ class CleanedOutput
 
   private
 
-  attr_reader :output, :redactions
+  attr_reader :output, :redactions, :max_body_size
 
   def output_with_transforms_applied
     truncate(uncolorize(redact(output)))
   end
 
   def truncate(out)
-    out[-64_000..-1] || out
+    out[-max_body_size..-1] || out
   end
 
   def uncolorize(out)

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -30,7 +30,7 @@ class CleanedOutput
   end
 
   def redact(out)
-    redactions.reject { |r| r.nil? || r.empty? }.reduce(out) do |s, redaction|
+    redactions.compact.reject(&:empty?).reduce(out) do |s, redaction|
       s.gsub(ERB::Util.url_encode(redaction), 'REDACTED')
     end
   end

--- a/lib/cleaned_output.rb
+++ b/lib/cleaned_output.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'colorize'
+require 'erb'
+
+class CleanedOutput
+  def initialize(output:, redactions: [])
+    @output = output
+    @redactions = redactions
+  end
+
+  def to_s
+    output_with_transforms_applied
+  end
+
+  private
+
+  attr_reader :output, :redactions
+
+  def output_with_transforms_applied
+    truncate(uncolorize(redact(output)))
+  end
+
+  def truncate(out)
+    out[-64_000..-1] || out
+  end
+
+  def uncolorize(out)
+    out.uncolorize
+  end
+
+  def redact(out)
+    redactions.reduce(out) do |s, redaction|
+      s.gsub(ERB::Util.url_encode(redaction), 'REDACTED')
+    end
+  end
+end

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -24,6 +24,22 @@ describe 'CleanedOutput' do
     end
   end
 
+  describe 'passing nil as a redaction' do
+    subject { CleanedOutput.new(output: 'Hello, world', redactions: [nil]) }
+
+    it 'returns the expected output' do
+      subject.to_s.must_equal 'Hello, world'
+    end
+  end
+
+  describe 'passing an empty string as a redaction' do
+    subject { CleanedOutput.new(output: 'Hello, world', redactions: ['']) }
+
+    it 'returns the expected output' do
+      subject.to_s.must_equal 'Hello, world'
+    end
+  end
+
   describe 'with color escape codes in output' do
     let(:output) { '[0;31;49mTest[0m' }
     subject { CleanedOutput.new(output: output) }

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -40,6 +40,14 @@ describe 'CleanedOutput' do
     end
   end
 
+  describe 'passed nil instead of redactions array' do
+    subject { CleanedOutput.new(output: 'Hello, world', redactions: nil) }
+
+    it 'returns the expected output' do
+      subject.to_s.must_equal 'Hello, world'
+    end
+  end
+
   describe 'with color escape codes in output' do
     let(:output) { '[0;31;49mTest[0m' }
     subject { CleanedOutput.new(output: output) }

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -24,6 +24,19 @@ describe 'CleanedOutput' do
     end
   end
 
+  describe 'redacting single string from output' do
+    subject do
+      CleanedOutput.new(
+        output:     'My password is secret',
+        redactions: 'secret'
+      )
+    end
+
+    it 'removes the key from the output' do
+      subject.to_s.must_equal 'My password is REDACTED'
+    end
+  end
+
   describe 'passing nil as a redaction' do
     subject { CleanedOutput.new(output: 'Hello, world', redactions: [nil]) }
 

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -40,5 +40,13 @@ describe 'CleanedOutput' do
     it 'only returns that last 64k' do
       subject.to_s.size.must_equal 64_000
     end
+
+    describe 'configured to a lower max size' do
+      subject { CleanedOutput.new(output: output, max_body_size: 100) }
+
+      it 'only returns the requested body size' do
+        subject.to_s.size.must_equal 100
+      end
+    end
   end
 end

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../lib/cleaned_output'
+
+describe 'CleanedOutput' do
+  describe 'basic output' do
+    subject { CleanedOutput.new(output: 'Hello, world') }
+
+    it 'returns it untouched' do
+      subject.to_s.must_equal 'Hello, world'
+    end
+  end
+
+  describe 'redacting strings from output' do
+    subject do
+      CleanedOutput.new(
+        output:     'key=secret pw=opensesame',
+        redactions: %w(secret opensesame)
+      )
+    end
+
+    it 'removes the key from the output' do
+      subject.to_s.must_equal 'key=REDACTED pw=REDACTED'
+    end
+  end
+
+  describe 'with color escape codes in output' do
+    let(:output) { '[0;31;49mTest[0m' }
+    subject { CleanedOutput.new(output: output) }
+
+    it 'strips escape codes' do
+      subject.to_s.must_equal 'Test'
+    end
+  end
+
+  describe 'large output' do
+    let(:output) { 'x' * 100_000 }
+    subject { CleanedOutput.new(output: output) }
+
+    it 'only returns that last 64k' do
+      subject.to_s.size.must_equal 64_000
+    end
+  end
+end

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -42,10 +42,10 @@ describe 'CleanedOutput' do
     end
 
     describe 'configured to a lower max size' do
-      subject { CleanedOutput.new(output: output, max_body_size: 100) }
+      subject { CleanedOutput.new(output: 'Hello, world', max_body_size: 5) }
 
-      it 'only returns the requested body size' do
-        subject.to_s.size.must_equal 100
+      it 'only returns the last n characters of the body' do
+        subject.to_s.must_equal 'world'
       end
     end
   end


### PR DESCRIPTION
This is a subset of https://github.com/everypolitician/rebuilder/pull/63 which just introduces a cleaned up version of the `CleanedOutput` class. Hopefully doing this as a separate change will make things a bit simpler to review in smaller steps.

Fixes #43 
Part of #62 