### PR TITLE
Hotfix: require CleanedOutput

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,8 @@ Dotenv.load
 require 'active_support/core_ext'
 require 'English'
 
+require_relative './lib/cleaned_output'
+
 configure :production do
   require 'rollbar/middleware/sinatra'
 

--- a/test/cleaned_output_test.rb
+++ b/test/cleaned_output_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'test_helper'
-require_relative '../lib/cleaned_output'
 
 describe 'CleanedOutput' do
   describe 'basic output' do


### PR DESCRIPTION
Make sure that the app requires CleanedOutput (and stop the test
explicitly requiring it itself, which disguised the problem)

Fixes
  https://github.com/everypolitician/everypolitician/issues/582
