### PR TITLE
[WIP] Prototype of moving build logic to shell script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'rake'
 gem 'rubocop'
 gem 'sidekiq'
 gem 'sinatra'
-gem 'with_git_repo'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
     everypolitician (0.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    git (1.3.0)
     hashdiff (0.2.3)
     hitimes (1.2.3)
     i18n (0.7.0)
@@ -96,8 +95,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    with_git_repo (0.3.0)
-      git (~> 1.3)
 
 PLATFORMS
   ruby
@@ -120,7 +117,6 @@ DEPENDENCIES
   sinatra
   vcr
   webmock
-  with_git_repo
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/README.md
+++ b/README.md
@@ -53,3 +53,22 @@ Use the `CleanedOutput` class to obtain a cleaned version of an external command
 cleaned_output = CleanedOutput.new(output: 'key=secret pw=password', redactions: ['secret', 'password'])
 puts cleaned_output.to_s # => "key=REDACTED pw=REDACTED"
 ```
+
+### Running external commands
+
+The main task this app performs is running the EveryPolitician build process as an external command and then creating a pull request with the output from the command. As such, one of the main classes in the system is the `ExternalCommand` class. This encapsulates running an external command, checking for errors and returning the output.
+
+To use this class create an instance of `ExternalCommand` and pass `command` and `env` keyword arguments to the constructor. The `command` should be a string representing the external command to execute, and `env` is an optional hash containing environment variables that should be set, or if they are `nil`, unset.
+
+Note that a given instance will only run an external command once. Create a new instance if you need to run the command again.
+
+```ruby
+command = ExternalCommand.new(
+  command: 'echo "Hello, $name."',
+  env: { 'name' => 'Bob' }
+).run
+
+# Now you can access the output and status of the command.
+command.output # => "Hello, Bob.\n"
+command.success? # => true
+```

--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,6 @@ Bundler.require
 Dotenv.load
 
 require 'active_support/core_ext'
-require 'English'
 
 require_relative './lib/cleaned_output'
 

--- a/bin/everypolitician-data-builder
+++ b/bin/everypolitician-data-builder
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Unset bundler environment variables so it uses the correct Gemfile etc.
+unset BUNDLE_GEMFILE
+unset BUNDLE_BIN_PATH
+unset RUBYOPT
+unset RUBYLIB
+unset NOKOGIRI_USE_SYSTEM_LIBRARIES
+
+set -x
+
+setup-everypolitician-data() {
+  git clone "$GIT_CLONE_URL" everypolitician-data
+  cd everypolitician-data
+  git checkout -b "$BRANCH_NAME"
+  bundle install --quiet --jobs 4 --without test
+}
+
+build-everypolitician-data() {
+  pushd "$LEGISLATURE_DIRECTORY"
+  if [[ -n "$SOURCE_NAME" ]]; then
+    REBUILD_SOURCE="$SOURCE_NAME" bundle exec rake clean default
+  else
+    bundle exec rake clobber default
+  fi
+  git add .
+  git commit -m "$COUNTRY_NAME: Refresh from upstream changes" || true
+  popd
+  build-countries-json
+}
+
+build-countries-json() {
+  EP_COUNTRY_REFRESH="$COUNTRY_SLUG" bundle exec rake countries.json
+  git add countries.json
+  git commit -m "Refresh countries.json" || true
+}
+
+save-everypolitician-data() {
+  git push origin HEAD
+}
+
+main() {
+  setup-everypolitician-data
+  # Do the build in a subshell so we stay in the correct directory.
+  (build-everypolitician-data)
+  save-everypolitician-data
+}
+
+main

--- a/lib/external_command.rb
+++ b/lib/external_command.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'English'
+require_relative 'external_command/result'
+
+class ExternalCommand
+  def initialize(command:, env: {})
+    @command = command
+    @env = env
+  end
+
+  def run
+    Result.new(
+      output:       IO.popen(default_env.merge(env), command, &:read),
+      child_status: $CHILD_STATUS
+    )
+  end
+
+  private
+
+  attr_reader :env, :command
+
+  # Unset bundler environment variables so it uses the correct Gemfile etc.
+  def default_env
+    @default_env ||= {
+      'BUNDLE_GEMFILE'                => nil,
+      'BUNDLE_BIN_PATH'               => nil,
+      'RUBYOPT'                       => nil,
+      'RUBYLIB'                       => nil,
+      'NOKOGIRI_USE_SYSTEM_LIBRARIES' => '1',
+    }
+  end
+end

--- a/lib/external_command.rb
+++ b/lib/external_command.rb
@@ -9,9 +9,9 @@ class ExternalCommand
   end
 
   def run
-    Dir.mktmpdir do
+    with_tmp_dir do
       Result.new(
-        output:       IO.popen(default_env.merge(env), command, &:read),
+        output:       IO.popen(env, command, &:read),
         child_status: $CHILD_STATUS
       )
     end
@@ -21,14 +21,9 @@ class ExternalCommand
 
   attr_reader :env, :command
 
-  # Unset bundler environment variables so it uses the correct Gemfile etc.
-  def default_env
-    @default_env ||= {
-      'BUNDLE_GEMFILE'                => nil,
-      'BUNDLE_BIN_PATH'               => nil,
-      'RUBYOPT'                       => nil,
-      'RUBYLIB'                       => nil,
-      'NOKOGIRI_USE_SYSTEM_LIBRARIES' => '1',
-    }
+  def with_tmp_dir(&block)
+    Dir.mktmpdir do |tmp_dir|
+      Dir.chdir(tmp_dir, &block)
+    end
   end
 end

--- a/lib/external_command.rb
+++ b/lib/external_command.rb
@@ -9,10 +9,12 @@ class ExternalCommand
   end
 
   def run
-    Result.new(
-      output:       IO.popen(default_env.merge(env), command, &:read),
-      child_status: $CHILD_STATUS
-    )
+    Dir.mktmpdir do
+      Result.new(
+        output:       IO.popen(default_env.merge(env), command, &:read),
+        child_status: $CHILD_STATUS
+      )
+    end
   end
 
   private

--- a/lib/external_command/result.rb
+++ b/lib/external_command/result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ExternalCommand
+  class Result
+    attr_reader :output
+
+    def initialize(output:, child_status:)
+      @output = output
+      @child_status = child_status
+    end
+
+    def success?
+      child_status.success?
+    end
+
+    private
+
+    attr_reader :child_status
+  end
+end

--- a/test/external_command_test.rb
+++ b/test/external_command_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'test_helper'
+require_relative '../lib/external_command'
+
+describe 'ExternalCommand' do
+  describe 'running a simple command' do
+    subject { ExternalCommand.new(command: 'echo Hello, world.').run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "Hello, world.\n"
+    end
+
+    it 'is considered to be successful' do
+      subject.success?.must_equal true
+    end
+  end
+
+  describe 'running a command with environment variables set' do
+    subject { ExternalCommand.new(command: 'echo Hello, $name.', env: { 'name' => 'Bob' }).run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "Hello, Bob.\n"
+    end
+
+    it 'is considered to be successful' do
+      subject.success?.must_equal true
+    end
+  end
+
+  describe 'running an external command that fails' do
+    subject { ExternalCommand.new(command: 'echo fail; exit 1').run }
+
+    it 'returns the expected output' do
+      subject.output.must_equal "fail\n"
+    end
+
+    it 'is considered to be a failure' do
+      subject.success?.must_equal false
+    end
+  end
+end

--- a/test/external_command_test.rb
+++ b/test/external_command_test.rb
@@ -38,4 +38,13 @@ describe 'ExternalCommand' do
       subject.success?.must_equal false
     end
   end
+
+  describe 'running commands in a tmpdir' do
+    let(:other_command) { ExternalCommand.new(command: 'pwd').run }
+    subject { ExternalCommand.new(command: 'pwd').run }
+
+    it 'runs in a different directory each time' do
+      subject.output.wont_equal other_command.output
+    end
+  end
 end


### PR DESCRIPTION
This is a spike to see if moving the complicated logic that deals with git, bundler and rake can be simplified by pushing it off into a shell script. It seems that this does indeed help to simplify things.

It builds on top of the `ExternalCommand` class from #63.

In particular this allows us to:

- Simplify the `git(1)` logic and get rid of the `with_git_repo` dependency now
- Just call one external command and then handle the return value from it, which would help fix https://github.com/everypolitician/rebuilder/issues/52
- Potentially swap out the script that's run so that when testing it can be a very small/fast script, which would effectively fix #44 

Part of #62 