### PR TITLE
Move build to shell script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'rake'
 gem 'rubocop'
 gem 'sidekiq'
 gem 'sinatra'
-gem 'with_git_repo'
 
 group :test do
   gem 'minitest'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ GEM
     everypolitician (0.2.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    git (1.3.0)
     hashdiff (0.2.3)
     hitimes (1.2.3)
     i18n (0.7.0)
@@ -96,8 +95,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    with_git_repo (0.3.0)
-      git (~> 1.3)
 
 PLATFORMS
   ruby
@@ -120,7 +117,6 @@ DEPENDENCIES
   sinatra
   vcr
   webmock
-  with_git_repo
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app.rb
+++ b/app.rb
@@ -84,14 +84,6 @@ class RebuilderJob
 
   private
 
-  def with_git_repo
-    @with_git_repo ||= WithGitRepo.new(
-      clone_url:  clone_url,
-      user_name:  github.login,
-      user_email: github.emails.first[:email]
-    )
-  end
-
   def clone_url
     @clone_url ||= URI.parse(repo.clone_url).tap do |repo_clone_url|
       repo_clone_url.user = github.login

--- a/bin/everypolitician-data-builder
+++ b/bin/everypolitician-data-builder
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+git() {
+  command git -c user.name=everypoliticianbot -c user.email=team@everypolitician.org "$@"
+}
+
+# Unset bundler environment variables so it uses the correct Gemfile etc.
+unset BUNDLE_GEMFILE
+unset BUNDLE_BIN_PATH
+unset RUBYOPT
+unset RUBYLIB
+unset NOKOGIRI_USE_SYSTEM_LIBRARIES
+
+setup-everypolitician-data() {
+  git clone --quiet "$GIT_CLONE_URL" everypolitician-data
+  cd everypolitician-data
+  git checkout -b "$BRANCH_NAME"
+  bundle install --quiet --jobs 4 --without test
+}
+
+build-everypolitician-data() {
+  # Do the build in a subshell so we stay in the correct directory.
+  (
+    cd "$LEGISLATURE_DIRECTORY"
+    if [[ -n "$SOURCE_NAME" ]]; then
+      REBUILD_SOURCE="$SOURCE_NAME" bundle exec rake clean default
+    else
+      bundle exec rake clobber default
+    fi
+    git add .
+    git commit -m "$COUNTRY_NAME: Refresh from upstream changes" || true
+  )
+  build-countries-json
+}
+
+build-countries-json() {
+  EP_COUNTRY_REFRESH="$COUNTRY_SLUG" bundle exec rake countries.json
+  git add countries.json
+  git commit -m "Refresh countries.json" || true
+}
+
+save-everypolitician-data() {
+  git push --quiet origin HEAD
+}
+
+main() {
+  setup-everypolitician-data
+  build-everypolitician-data
+  save-everypolitician-data
+}
+
+main


### PR DESCRIPTION
This moves the steps required for obtaining the everypolitician-data repo, performing a rebuild of a legislature, and saving the results, out of Ruby and into a shell script.

This unlocks the following:

- Simplify the `git(1)` logic and get rid of the `with_git_repo` dependency now
- Changing to a shallow clone should be simple now https://github.com/everypolitician/rebuilder/issues/69
- Only calling one script makes error handling simpler https://github.com/everypolitician/rebuilder/issues/52
- We can potentially use a simple script when running tests locally to avoid the overhead of cloning the ep-data repo #44 

Fixes #67 

# Notes to reviewer

The plan is once this is merged the logic for calling an external command can be moved into an `ExternalCommand` class, see #45 for more details. So this refactoring is just a stepping stone to make that a bit easier.