### PR TITLE
Do a shallow clone of everypolitician-data repo

### DIFF
--- a/bin/everypolitician-data-builder
+++ b/bin/everypolitician-data-builder
@@ -14,7 +14,7 @@ unset RUBYLIB
 unset NOKOGIRI_USE_SYSTEM_LIBRARIES
 
 setup-everypolitician-data() {
-  git clone --quiet "$GIT_CLONE_URL" everypolitician-data
+  git clone --quiet --depth=1 "$GIT_CLONE_URL" everypolitician-data
   cd everypolitician-data
   git checkout -b "$BRANCH_NAME"
   bundle install --quiet --jobs 4 --without test
@@ -32,7 +32,9 @@ build-everypolitician-data() {
     git add .
     git commit -m "$COUNTRY_NAME: Refresh from upstream changes" || true
   )
-  build-countries-json
+
+  # FIXME: Temporarily disabled because it doesn't work with a shallow clone of everypolitician-data.
+  # build-countries-json
 }
 
 build-countries-json() {


### PR DESCRIPTION
A large proportion of the build time is currently spent cloning the
everypolitician-data repo, which is now at least 1GB in size on the
wire. To reduce the amount of unnecessary data that is being moved
around this change switches to a shallow clone of the repo.

Because we're using a shallow clone I've also had to disable the
countries.json build step, because that relies on git history to work
currently. We'll need to either remove the dependency on git history, or
have it happen at a different stage.

Fixes #69 

# Notes to merger

Don't merge this pull request until the following have been completed:

- [x] Change the target branch to `master` once #70 has been merged.