### PR TITLE
Make a PR even if only the Positions file changes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -139,7 +139,7 @@ class CreatePullRequestJob
       return
     end
     changes = github.compare(EVERYPOLITICIAN_DATA_REPO, 'master', branch)
-    changed_files = changes[:files].map { |f| File.basename(f[:filename]) }
+    changed_files = changes[:files].map { |f| f[:filename].split('/').drop(3).join('/') }
     unless (changed_files & EXPECTED_FILES).any?
       warn 'No usable change detected, skipping'
       return


### PR DESCRIPTION
Rather than bailing out early unless the Popolo file has changed, we
should also continue if the only change is to the Positions file, e.g.
from a Cabinet Scraper rebuild.

Fixes https://github.com/everypolitician/rebuilder/issues/74

@chrismytton: this is untested, as I don't really know _how_ to test
it. IIRC you have a parallel set-up you could check this with?