### PR TITLE
Move rubocop to 'development' group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'octokit'
 gem 'puma'
 gem 'rake'
 gem 'rest-client'
-gem 'rubocop'
 gem 'sidekiq'
 gem 'sinatra'
 
@@ -30,6 +29,7 @@ end
 
 group :development do
   gem 'derailed'
+  gem 'rubocop'
 end
 
 # Report exceptions to rollbar.com

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ group :test do
   gem 'webmock'
 end
 
+group :development do
+  gem 'derailed'
+end
+
 # Report exceptions to rollbar.com
 gem 'oj', '~> 2.12.14'
 gem 'rollbar', '~> 2.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,12 +16,23 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    benchmark-ips (2.7.2)
     coderay (1.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    derailed (0.1.0)
+      derailed_benchmarks
+    derailed_benchmarks (1.3.5)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      heapy (~> 0)
+      memory_profiler (~> 0)
+      rack (>= 1)
+      rake (> 10, < 13)
+      thor (~> 0.19)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
@@ -30,13 +41,16 @@ GEM
       require_all
     faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
+    get_process_mem (0.2.2)
     hashdiff (0.3.7)
+    heapy (0.1.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
     json5 (0.0.1)
+    memory_profiler (0.9.11)
     method_source (0.9.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -97,6 +111,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.4)
       tilt (~> 2.0)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
@@ -117,6 +132,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   colorize
+  derailed
   dotenv
   everypolitician
   everypolitician-popolo!


### PR DESCRIPTION
Following the suggestion at https://devcenter.heroku.com/articles/ruby-memory-use to add `derailed`, this revealed that rubocop used the majority of memory at boot:

```
TOP: 70.9453 MiB
  rubocop: 50.1875 MiB
    parser: 12.9375 MiB
      parser/lexer: 10.4375 MiB
      parser/builders/default: 0.7227 MiB
    ruby-progressbar: 0.6836 MiB
    resolv: 0.4961 MiB
    rainbow: 0.3711 MiB
  octokit: 8.457 MiB
    octokit/client: 7.1758 MiB
      octokit/connection: 5.875 MiB (Also required by: octokit/enterprise_admin_client, octokit/enterprise_management_console_client)
        sawyer: 5.7852 MiB (Also required by: ext/sawyer/relation)
          /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent: 5.4648 MiB
            addressable/template: 3.8516 MiB
              addressable/uri: 3.4805 MiB
                addressable/idna: 2.3789 MiB
                  addressable/idna/pure: 2.3398 MiB
            faraday: 1.5586 MiB (Also required by: octokit/middleware/follow_redirects, octokit/response/raise_error)
    octokit/default: 1.125 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http: 0.9609 MiB
        net/https: 0.9141 MiB (Also required by: rollbar)
          net/http: 0.9141 MiB (Also required by: /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient, rubocop)
            net/protocol: 0.3594 MiB (Also required by: rollbar)
              socket: 0.3242 MiB (Also required by: puma, ipaddr, and 4 others)
  rest-client: 6.25 MiB
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient: 6.2461 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/abstract_response: 3.0742 MiB
        http-cookie: 3.0547 MiB
          http/cookie: 3.0547 MiB
            domain_name: 3.0078 MiB
              domain_name/etld_data: 2.8359 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/request: 2.8711 MiB
        mime/types: 2.7734 MiB (Also required by: /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/payload)
          mime/types/registry: 2.5664 MiB
  active_support: 2.2695 MiB
    active_support/logger: 1.2891 MiB
      active_support/logger_silence: 1.2344 MiB
        concurrent: 1.1992 MiB
    active_support/dependencies/autoload: 0.9453 MiB
      active_support/inflector/methods: 0.9375 MiB
        active_support/inflections: 0.9258 MiB
          active_support/inflector/inflections: 0.7852 MiB
  everypolitician: 1.3164 MiB
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/everypolitician-0.20.0/lib/everypolitician/legislative_period.rb: 0.6719 MiB
      csv: 0.6523 MiB
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/everypolitician-0.20.0/lib/everypolitician/legislature.rb: 0.3789 MiB
      everypolitician/popolo: 0.375 MiB (Also required by: TOP)
  rake: 1.2031 MiB
    rake/rake_module: 0.5781 MiB
      rake/application: 0.5508 MiB (Also required by: rake)
        rake/file_list: 0.3438 MiB (Also required by: rake)
    optparse: 0.375 MiB (Also required by: rake/application, rubocop)
```

By moving `rubocop` to the `development` group, this reduced to:

```
TOP: 29.7461 MiB
  octokit: 8.8984 MiB
    octokit/client: 7.5 MiB
      octokit/connection: 6.0508 MiB (Also required by: octokit/enterprise_admin_client, octokit/enterprise_management_console_client)
        sawyer: 5.9336 MiB (Also required by: ext/sawyer/relation)
          /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/sawyer-0.8.1/lib/sawyer/agent: 5.5938 MiB
            addressable/template: 3.9688 MiB
              addressable/uri: 3.5859 MiB
                addressable/idna: 2.4219 MiB
                  addressable/idna/pure: 2.375 MiB
                public_suffix: 0.3125 MiB
            faraday: 1.5547 MiB (Also required by: octokit/middleware/follow_redirects, octokit/response/raise_error)
              /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.3/lib/faraday/options: 0.3008 MiB
    octokit/default: 1.1836 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/faraday-0.15.3/lib/faraday/adapter/net_http: 0.9727 MiB
        net/https: 0.9141 MiB (Also required by: rollbar)
          net/http: 0.9141 MiB (Also required by: /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient)
            net/protocol: 0.4336 MiB (Also required by: rollbar)
              socket: 0.3789 MiB (Also required by: puma, ipaddr, and 3 others)
  rest-client: 6.2813 MiB
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient: 6.2734 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/abstract_response: 3.3945 MiB
        http-cookie: 3.3906 MiB
          http/cookie: 3.3906 MiB
            domain_name: 3.2539 MiB
              domain_name/etld_data: 3.1602 MiB
      /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/request: 2.5508 MiB
        mime/types: 2.3633 MiB (Also required by: /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rest-client-2.0.2/lib/restclient/payload)
          mime/types/registry: 2.1641 MiB
  sinatra: 6.1016 MiB
    sinatra/main: 6.0859 MiB
      sinatra/base: 5.9961 MiB
        mustermann/sinatra: 1.793 MiB
          mustermann/ast/pattern: 1.3359 MiB
            mustermann/expander: 0.3125 MiB
        sinatra/show_exceptions: 1.3594 MiB
          rack/show_exceptions: 1.2031 MiB
            rack/request: 0.7148 MiB (Also required by: rack/response, rack/session/cookie)
              rack/utils: 0.4297 MiB (Also required by: rack/show_exceptions, rack/response)
            erb: 0.332 MiB
        mustermann: 0.5 MiB (Also required by: mustermann/sinatra, mustermann/identity, and 2 others)
        tilt: 0.3906 MiB
  active_support: 2.543 MiB
    active_support/logger: 1.4531 MiB
      active_support/logger_silence: 1.3945 MiB
        concurrent: 1.3633 MiB
          concurrent/executors: 0.4336 MiB
          concurrent/configuration: 0.3516 MiB (Also required by: concurrent/scheduled_task, concurrent/options, and 2 others)
    active_support/dependencies/autoload: 0.9844 MiB
      active_support/inflector/methods: 0.9648 MiB
        active_support/inflections: 0.9102 MiB
          active_support/inflector/inflections: 0.7344 MiB
            active_support/deprecation: 0.3594 MiB
  sidekiq: 2.1719 MiB
    sidekiq/redis_connection: 1.8672 MiB
      redis: 1.6758 MiB
  everypolitician: 1.1211 MiB
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/everypolitician-0.20.0/lib/everypolitician/legislature.rb: 0.4453 MiB
      everypolitician/popolo: 0.3945 MiB (Also required by: TOP)
    /Users/tony/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/everypolitician-0.20.0/lib/everypolitician/legislative_period.rb: 0.3906 MiB
      csv: 0.3711 MiB
  rake: 1.0469 MiB
    rake/rake_module: 0.4531 MiB
      rake/application: 0.4492 MiB (Also required by: rake)
    optparse: 0.3359 MiB (Also required by: rake/application)
  rollbar: 0.9336 MiB
    rollbar/notifier: 0.4727 MiB
```