### PR TITLE
Update to Ruby 2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
-rvm:
-  - 2.3.3
+rvm: 2.4.4
 before_install: gem install bundler -v 1.10.6
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '2.3.3'
+ruby '2.4.4'
 
 gem 'activesupport', require: 'active_support'
 gem 'colorize'
@@ -33,5 +33,5 @@ group :development do
 end
 
 # Report exceptions to rollbar.com
-gem 'oj', '~> 2.12.14'
-gem 'rollbar', '~> 2.13'
+gem 'oj'
+gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     netrc (0.11.0)
     octokit (4.12.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (2.12.14)
+    oj (3.6.10)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -140,13 +140,13 @@ DEPENDENCIES
   minitest
   minitest-around
   octokit
-  oj (~> 2.12.14)
+  oj
   pry
   puma
   rack-test
   rake
   rest-client
-  rollbar (~> 2.13)
+  rollbar
   rubocop
   sidekiq
   sinatra
@@ -154,7 +154,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.2
+   1.16.5


### PR DESCRIPTION
Heroku Stack cedar-14 is deprecated, and updating to heroku-18 requires
ruby 2.4.4 at a minimum.