### PR TITLE
Return to ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache: bundler
-rvm: 2.4.4
+rvm: 2.3.3
 before_install: gem install bundler -v 1.10.6
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '2.4.4'
+ruby '2.3.3'
 
 gem 'activesupport', require: 'active_support'
 gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.4p296
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.16.5


### PR DESCRIPTION
2.4.4 is causing too many problems, so revert heroku back to cedar-14
for now, and go back to ruby 2.3