### PR TITLE
Log the start of creating a Pull Request

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -169,6 +169,7 @@ class CreatePullRequestJob
   EXPECTED_FILES = ['ep-popolo-v1.0.json', 'unstable/positions.csv'].freeze
 
   def perform(branch, title, body_key)
+    logger.info("Begin PR #{title}")
     # The branch won't exist if there were no changes when the rebuild was run.
     unless branch_exists?(branch)
       warn "Couldn't find branch: #{branch}"


### PR DESCRIPTION
Currently a PR build can look like:

```
2018-09-26T13:37:47.386173+00:00 app[worker.1]: 4 TID-gq1esh6b0 CreatePullRequestJob JID-0033df4236648c304437f1dd INFO: start
2018-09-26T13:37:47.758140+00:00 app[worker.1]: No usable change detected, skipping
2018-09-26T13:37:47.758183+00:00 app[worker.1]: 4 TID-gq1esh6b0 CreatePullRequestJob JID-0033df4236648c304437f1dd INFO: done: 0.372 sec
```

This doesn't give us any useful information about which legislature was
being built, so we should also log the PR title we would use were we
successful.