### PR TITLE
Make skip messages INFO rather than WARN

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -80,7 +80,7 @@ class RebuilderJob
     # This can be done in seconds rather than minutes
     if source
       if skip_reason = Build.new(legislature, source).skip_reason
-        logger.warn(skip_reason)
+        logger.info("Skip #{country_slug}/#{legislature_slug}/#{source}: #{skip_reason}")
         return
       end
     end


### PR DESCRIPTION
These aren't really warnings; they're informational. It's also helpful
to know which source we're working with, so we can grep these out of the
logs.