### PR TITLE
use Travis' default bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
 rvm: 2.4.4
-before_install: gem install bundler -v 1.10.6
 services:
   - redis-server


### PR DESCRIPTION
Historically we wanted to force a specific version of `bundler` under
certain circumstances. Those shouldn't be relevant any more, so allow
travis to use its own default version.