### PR TITLE
Allow rebuilds of non-morph sources

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -48,6 +48,7 @@ class Build
 
   def skip_reason
     return 'No source' unless source
+    return unless source.morph?
     return 'No github data' if source.current_data.to_s.empty?
     return 'No morph data' if source.fresh_data.to_s.empty?
     return 'No morph changes' if source.current_data == source.fresh_data
@@ -230,8 +231,8 @@ module EveryPolitician
     end
 
     def stanza(name)
-      instructions[:sources].find do |src|
-        src[:create] && (src[:create][:from] == 'morph') && (src[:file].include? name)
+      instructions[:sources].select { |src| src[:create] }.find do |src|
+        src[:file].include? name
       end
     end
   end
@@ -244,9 +245,13 @@ module EveryPolitician
       @legislature = legislature
     end
 
+    def morph?
+      creation[:from].to_s == 'morph'
+    end
+
     # TODO: handle all the other types of source
     def fresh_data
-      return '' unless creation[:from].to_s == 'morph'
+      return '' unless morph?
 
       @fresh_data ||= MorphData.new(creation[:scraper]).query(creation[:query]) rescue nil
     end

--- a/test/instructions_test.rb
+++ b/test/instructions_test.rb
@@ -18,8 +18,8 @@ describe 'Instructions' do
       src.send(:github_data_url).must_include 'sources/morph/wikidata.csv'
     end
 
-    it 'knows there is no gender source' do
-      subject.source('gender').must_be_nil
+    it 'knows gender is not a morph-based source' do
+      subject.source('gender').morph?.must_equal false
     end
 
     it 'handles a 400 result from morph' do

--- a/test/shortcircuit_test.rb
+++ b/test/shortcircuit_test.rb
@@ -26,5 +26,9 @@ describe Build do
       stub_request(:get, /api.morph.io/).to_return(status: 400)
       Build.new(legislature, 'official').skip_reason.must_equal 'No morph data'
     end
+
+    it 'rebuilds a non-morph source' do
+      Build.new(legislature, 'gender').skip_reason.must_be_nil
+    end
   end
 end


### PR DESCRIPTION
If a source is not morph-based, but re-createable, we should *always*
rebuild, rather than *never* rebuilding.